### PR TITLE
Add default case for switch statements

### DIFF
--- a/gui/inventory-app/app/src/main/java/org/moserp/MainActivity.java
+++ b/gui/inventory-app/app/src/main/java/org/moserp/MainActivity.java
@@ -151,6 +151,11 @@ public class MainActivity extends ToolbarActivity {
                             case R.id.action_settings:
                                 startActivity(new Intent(getApplicationContext(), PreferencesActivity_.class));
                                 return true;
+                            //missing default case
+                            default:
+                                // add default case
+                                 break;
+
                         }
                         return false;
                     }


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html